### PR TITLE
docs:update to mention that Maple also works with jackson-jr

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This might be a common use-case for jvm apps running in kubernetes.
 If that is your use case, you might prefer maple over logback because:
 
 - Maple is specialized for this use-case, working out of the box with sane defaults;
-- If you already have [jackson](https://github.com/FasterXML/jackson-core/), [gson](https://github.com/google/gson) or any [jakarta/json-p](https://github.com/jakartaee/jsonp-api) compliant library, maple will use it to write json logs, so no extra dependencies needed;
+- If you already have [jackson](https://github.com/FasterXML/jackson-core/), [jackson-jr](https://github.com/FasterXML/jackson-jr), [gson](https://github.com/google/gson) or any [jakarta/json-p](https://github.com/jakartaee/jsonp-api) compliant library, maple will use it to write json logs, so no extra dependencies needed;
 - It is very optimized, with impressive performance when compared to logback;
 - It is also designed not consume almost any runtime memory, so it won't cause GC pressure;
 - If you want to configure, the extension config library [maple-yaml-config](maple-yaml-config/README.md) allows you to configure maple in yaml,


### PR DESCRIPTION
I updated the README.md to mention that Maple also works with jackson-jr.

Jackson jr is a compact alternative to full [Jackson Databind](https://github.com/FasterXML/jackson-databind) component. It implements a subset of functionality, for cases where:

1. Size of jar matters (jackson-jr-objects is bit over 100 kB)
2. Startup time matters (jackson-jr has very low initialization overhead)