### PR TITLE
Refactor Clock

### DIFF
--- a/bin/throughput
+++ b/bin/throughput
@@ -49,6 +49,8 @@ cd "${localdir}/.." && {
   batch 2 10000
   batch 3 5000
   batch 4 5000
+  batch 16 5000
+  batch 32 5000
 }
 
 sudo umount out/

--- a/maple-core/src/main/java/maple/core/internals/Clock.java
+++ b/maple-core/src/main/java/maple/core/internals/Clock.java
@@ -1,7 +1,9 @@
 package maple.core.internals;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReentrantLock;
 
 public final class Clock {
     private Clock() {}
@@ -10,6 +12,7 @@ public final class Clock {
     //  i.e. allow the clock to be updated every second, to reduce the load.
     //  Also, it is not necessarily precise already because it takes half a ms to update.
     private static final long precision = 1_000_000;
+    private static Lock startThreadLock = new ReentrantLock();
 
     private static final AtomicLong timestamp = new AtomicLong(0L);
     private static final Thread clockThread = ThreadCreator.newThread("maple-clock-ticker", () -> {
@@ -20,14 +23,11 @@ public final class Clock {
     });
 
     public static long getTimestamp() {
-        if (!clockThread.isAlive()) {
-            synchronized (clockThread) {
-                if (!clockThread.isAlive()) {
-                    // We preload the current value just in case we return before the thread updates
-                    timestamp.updateAndGet(ignored -> System.currentTimeMillis());
-                    clockThread.start();
-                }
-            }
+        if (!clockThread.isAlive() && startThreadLock.tryLock()) {
+            // We preload the current value just in case we return before the thread updates
+            timestamp.updateAndGet(ignored -> System.currentTimeMillis());
+            clockThread.start();
+            startThreadLock.unlock();
         }
 
         return timestamp.get();

--- a/maple-core/src/main/java/maple/core/internals/Clock.java
+++ b/maple-core/src/main/java/maple/core/internals/Clock.java
@@ -8,17 +8,25 @@ import java.util.concurrent.locks.ReentrantLock;
 public final class Clock {
     private Clock() {}
 
-    // TODO make precision configurable;
-    //  i.e. allow the clock to be updated every second, to reduce the load.
-    //  Also, it is not necessarily precise already because it takes half a ms to update.
-    private static final long precision = 1_000_000;
-    private static Lock startThreadLock = new ReentrantLock();
+    // This is the amount of time, in nanos, that we will wait before incrementing.
+    // Keeping this at 1_000_000 ensure we tick at roughly 1ms;
+    private static final long refreshRate = 1_000_000;
 
-    private static final AtomicLong timestamp = new AtomicLong(0L);
+    // The precision is how far behind, in microseconds, we afford to be before we sync to System.currentTimeMillis
+    private static final long precision = 1_000;
+    private static final Lock startThreadLock = new ReentrantLock();
+
+    private static final AtomicLong timestamp = new AtomicLong(System.currentTimeMillis());
     private static final Thread clockThread = ThreadCreator.newThread("maple-clock-ticker", () -> {
         while(true) {
-            timestamp.set(System.currentTimeMillis());
-            LockSupport.parkNanos(precision);
+            var ts = timestamp.incrementAndGet();
+
+            // System.currentTimeMillis is known to be slow on linux.
+            // We can increment manually and sync at every second maybe?
+            if (ts % precision == 0) {
+                timestamp.set(System.currentTimeMillis());
+            }
+            LockSupport.parkNanos(refreshRate);
         }
     });
 


### PR DESCRIPTION
Clock is a facility that only exists to avoid doing the expensive `System.currentTimeMillis` in the logging thread.
By moving it to a static thread, we have a single place that ticks and returns a value for the time in milliseconds.

However, we were guarding against race conditions with `synchronized`, which makes the code slightly harder to read.

By using locks, we have a simple if check that will acquire the lock only once. This gives the same result as using
synchronized, but with better code redability.

Additionally, we trade-off usec precision by incrementing the clock manually a few times before syncing back to
`System.currentTimeMillis`. This should make the clock thread relatively lighter while also making it probably a
bit more precise in average.