### PR TITLE
Handle null-arguments correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,14 @@ jobs:
       - run:
           name: "Run tests"
           command: "./gradlew check"
+      - store_artifacts:
+        path: /root/project/penna-api/build/reports/pmd/
+      - store_artifacts:
+        path: /root/project/penna-core/build/reports/pmd/
+      - store_artifacts:
+        path: /root/project/penna-yaml-config/build/reports/pmd/
+      - store_artifacts:
+        path: /root/project/penna-dev/build/reports/pmd/
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,6 @@ jobs:
       - run:
           name: "Run tests"
           command: "./gradlew check"
-      - store_artifacts:
-        path: /root/project/penna-api/build/reports/pmd/
-      - store_artifacts:
-        path: /root/project/penna-core/build/reports/pmd/
-      - store_artifacts:
-        path: /root/project/penna-yaml-config/build/reports/pmd/
-      - store_artifacts:
-        path: /root/project/penna-dev/build/reports/pmd/
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,23 @@ the PATCH component is omitted when its value is `0`.
 - Move sinks and restructure output creation ([#59](https://github.com/hkupty/penna/pull/59))
 - Refactor integer to ascii logic ([#59](https://github.com/hkupty/penna/pull/59))
 - Various misc improvements for performance ([#59](https://github.com/hkupty/penna/pull/59))
+- Fix formatting for null arguments([#62](https://github.com/hkupty/penna/pull/62))
 
 ### `penna-yaml-config`
 
 #### Changed
 
 - Allow for configuring exception handling ([#53](https://github.com/hkupty/penna/pull/53))
+
+### `penna-dev`
+
+#### Added
+
+- Create dev runtime with enhanced readability for logs ([#61](https://github.com/hkupty/penna/pull/61))
+
+#### Changed
+
+- Fix formatting for null arguments([#62](https://github.com/hkupty/penna/pull/62))
 
 ## 0.6.2 - 2023-04-12
 

--- a/penna-api/build.gradle
+++ b/penna-api/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group 'com.hkupty.penna'
 
-version '0.7.0-alpha1'
+version '0.7.0-alpha2'
 
 repositories {
     mavenCentral()

--- a/penna-core/build.gradle
+++ b/penna-core/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.hkupty.penna'
-version '0.7.0-alpha1'
+version '0.7.0-alpha2'
 
 repositories {
     mavenCentral()

--- a/penna-core/src/main/java/penna/core/internals/DirectJson.java
+++ b/penna-core/src/main/java/penna/core/internals/DirectJson.java
@@ -96,9 +96,15 @@ public final class DirectJson implements Closeable {
                             (str.codePointAt(i - 1) != '\\' || str.codePointAt(i - 2) == '\\')
                     ) {
                         // Warning! Mismatch in arguments/template might cause exception.
-                        var argument = arguments[cursor++].toString();
-                        checkSpace(argument.length());
-                        writeRaw(argument);
+
+                        var argument = arguments[cursor++];
+                        if (argument == null) {
+                            writeRaw(NULL);
+                        } else {
+                            var argStr = argument.toString();
+                            checkSpace(argStr.length());
+                            writeRaw(argStr);
+                        }
 
                     } else {
                         int offset = str.codePointAt(i - 1) == '\\' ? 1 : 0;

--- a/penna-core/src/main/java/penna/core/internals/DirectJson.java
+++ b/penna-core/src/main/java/penna/core/internals/DirectJson.java
@@ -7,6 +7,8 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+
+import org.jetbrains.annotations.TestOnly;
 import org.jetbrains.annotations.VisibleForTesting;
 
 public final class DirectJson implements Closeable {
@@ -73,8 +75,8 @@ public final class DirectJson implements Closeable {
     // in JDK 10 the problem was solved. We are targeting JDK 17+, so the problem won't affect us.
     // Plus, any other alternative is significantly slower.
     @SuppressWarnings("PMD.AvoidFileStream")
-    @Deprecated() // Pass in a file channel instead
-    public DirectJson() {
+    @TestOnly
+    DirectJson() {
         this.backingOs = new FileOutputStream(FileDescriptor.out);
         this.channel = backingOs.getChannel();
     }

--- a/penna-core/src/test/java/penna/core/internals/DirectJsonTests.java
+++ b/penna-core/src/test/java/penna/core/internals/DirectJsonTests.java
@@ -2,7 +2,6 @@ package penna.core.internals;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,5 +110,16 @@ class DirectJsonTests {
         var charset = StandardCharsets.UTF_8;
         var chars = charset.decode(directJson.buffer).toString();
         assertEquals("{\"message\":\"hello http:\\\\\\\\world.com\"}", chars);
+    }
+
+    @Test
+    void can_write_nulls_when_formatting_string(){
+        DirectJson directJson = new DirectJson();
+
+        directJson.writeRawFormatting("String with {} placeholder", new Object[]{null});
+        directJson.buffer.flip();
+        var charset = StandardCharsets.UTF_8;
+        var chars = charset.decode(directJson.buffer).toString();
+        assertEquals("String with null placeholder", chars);
     }
 }

--- a/penna-dev/build.gradle
+++ b/penna-dev/build.gradle
@@ -9,6 +9,11 @@ group 'com.hkupty.penna'
 
 version '0.7.0-alpha1'
 
+pmd {
+    sourceSets = [sourceSets.main]
+    ruleSets("category/java/performance.xml", "category/java/bestpractices.xml", "category/java/errorprone.xml")
+}
+
 
 repositories {
     mavenCentral()

--- a/penna-dev/build.gradle
+++ b/penna-dev/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 group 'com.hkupty.penna'
 
-version '0.7.0-alpha1'
+version '0.7.0-alpha2'
 
 pmd {
     sourceSets = [sourceSets.main]

--- a/penna-dev/src/main/java/penna/dev/Formatter.java
+++ b/penna-dev/src/main/java/penna/dev/Formatter.java
@@ -1,8 +1,10 @@
 package penna.dev;
 
+@SuppressWarnings("PMD.AssignmentInOperand")
 public class Formatter {
 
-    public static String format(String message, Object[] args) {
+    @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
+    public static String format(String message, Object... args) {
         StringBuilder formattedMessage = new StringBuilder(message);
         int cursor = 0;
         int pos;

--- a/penna-dev/src/main/java/penna/dev/Formatter.java
+++ b/penna-dev/src/main/java/penna/dev/Formatter.java
@@ -1,0 +1,29 @@
+package penna.dev;
+
+public class Formatter {
+
+    public static String format(String message, Object[] args) {
+        StringBuilder formattedMessage = new StringBuilder(message);
+        int cursor = 0;
+        int pos;
+        int arg = 0;
+
+        while ((pos = formattedMessage.indexOf("{}", cursor)) >= 0 && arg < args.length) {
+            if (pos > 0 && formattedMessage.codePointAt(pos - 1) == '\\' &&
+                    (pos - 1 == 0 || formattedMessage.codePointBefore(pos - 1) != '\\')) {
+                cursor = pos + 1;
+            } else {
+                String formattedArg;
+                if (args[arg] == null) {
+                    formattedArg = "null";
+                } else {
+                    formattedArg = args[arg].toString();
+                }
+                arg++;
+                formattedMessage.replace(pos, pos + 2, formattedArg);
+            }
+        }
+
+        return formattedMessage.toString();
+    }
+}

--- a/penna-dev/src/main/java/penna/dev/config/DevConfigManager.java
+++ b/penna-dev/src/main/java/penna/dev/config/DevConfigManager.java
@@ -1,7 +1,5 @@
 package penna.dev.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import penna.api.config.ConfigManager;
 import penna.api.config.Configurable;
 

--- a/penna-dev/src/main/java/penna/dev/config/StandardConfigs.java
+++ b/penna-dev/src/main/java/penna/dev/config/StandardConfigs.java
@@ -5,6 +5,7 @@ import penna.api.config.Config;
 
 import static penna.api.config.ConfigManager.ConfigItem;
 
-public interface StandardConfigs {
-    ConfigItem DevOptimized = new ConfigItem.RootConfigItem(config -> new Config(Level.TRACE, config.fields(), config.exceptionHandling()));
+public final class StandardConfigs {
+    private StandardConfigs() {}
+    public static ConfigItem DevOptimized = new ConfigItem.RootConfigItem(config -> new Config(Level.TRACE, config.fields(), config.exceptionHandling()));
 }

--- a/penna-dev/src/main/java/penna/dev/sink/DevRuntimeSink.java
+++ b/penna-dev/src/main/java/penna/dev/sink/DevRuntimeSink.java
@@ -8,6 +8,7 @@ import penna.core.models.PennaLogEvent;
 import penna.core.sink.NonStandardSink;
 import penna.core.sink.Sink;
 import penna.core.slf4j.PennaMDCAdapter;
+import penna.dev.Formatter;
 import penna.dev.models.EnhancedLogEvent;
 
 import java.io.*;
@@ -93,7 +94,8 @@ public class DevRuntimeSink implements NonStandardSink, Closeable {
                 logData.append(" ");
             });
         }
-        logData.append(MessageFormatter.basicArrayFormat(logEvent.message, logEvent.arguments));
+
+        logData.append(Formatter.format(logEvent.message, logEvent.arguments));
 
         if(!logEvent.keyValuePairs.isEmpty()) {
             logData.append(colorize(" kvs{", Attribute.ITALIC()));

--- a/penna-dev/src/main/java/penna/dev/sink/DevRuntimeSink.java
+++ b/penna-dev/src/main/java/penna/dev/sink/DevRuntimeSink.java
@@ -18,7 +18,7 @@ import java.util.function.Supplier;
 import static com.diogonunes.jcolor.Ansi.colorize;
 
 public class DevRuntimeSink implements NonStandardSink, Closeable {
-    private static final int LOGGER_NAME_FOLDING_THRESHOLD = 25;
+    private static final int LOGGER_NAME_FOLDING_THRESHOLD = 50;
     FileOutputStream fos = new FileOutputStream(FileDescriptor.out);
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
     PrintStream ps = new PrintStream(fos, false);

--- a/penna-dev/src/main/java/penna/dev/sink/DevRuntimeSink.java
+++ b/penna-dev/src/main/java/penna/dev/sink/DevRuntimeSink.java
@@ -3,10 +3,8 @@ package penna.dev.sink;
 import com.diogonunes.jcolor.Attribute;
 import org.jetbrains.annotations.TestOnly;
 import org.slf4j.MDC;
-import org.slf4j.helpers.MessageFormatter;
 import penna.core.models.PennaLogEvent;
 import penna.core.sink.NonStandardSink;
-import penna.core.sink.Sink;
 import penna.core.slf4j.PennaMDCAdapter;
 import penna.dev.Formatter;
 import penna.dev.models.EnhancedLogEvent;
@@ -14,14 +12,14 @@ import penna.dev.models.EnhancedLogEvent;
 import java.io.*;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.function.Supplier;
 
 import static com.diogonunes.jcolor.Ansi.colorize;
 
 public class DevRuntimeSink implements NonStandardSink, Closeable {
     private static final int LOGGER_NAME_FOLDING_THRESHOLD = 50;
+    @SuppressWarnings("PMD.AvoidFileStream")
     FileOutputStream fos = new FileOutputStream(FileDescriptor.out);
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter timestampFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
     PrintStream ps = new PrintStream(fos, false);
     PennaMDCAdapter mdcAdapter;
 
@@ -44,18 +42,12 @@ public class DevRuntimeSink implements NonStandardSink, Closeable {
     }
 
     @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
-    @Override
-    public void write(PennaLogEvent logEvent) throws IOException {
-        init();
+    private static void emitHeader(StringBuilder log, PennaLogEvent logEvent) {
         var enhanced = EnhancedLogEvent.create(logEvent);
-        StringBuilder logData = new StringBuilder();
-        // Headers
-
-        logData.append(colorize(String.format("%6s", logEvent.level.toString()), Attribute.BOLD(), enhanced.accentColor()));
-        logData.append(" ");
-        logData.append(colorize(formatter.format(enhanced.timestamp()), Attribute.BOLD()));
-        logData.append(" ");
-        logData.append(colorize(new String(logEvent.threadName), Attribute.BOLD()));
+        log.append(colorize(String.format("%6s ", logEvent.level.toString()), Attribute.BOLD(), enhanced.accentColor()))
+                .append(colorize(timestampFormatter.format(enhanced.timestamp()), Attribute.BOLD()))
+                .append(' ')
+                .append(colorize(new String(logEvent.threadName), Attribute.BOLD()));
         var logger = new StringBuilder(new String(logEvent.logger));
         if (logEvent.logger.length > LOGGER_NAME_FOLDING_THRESHOLD) {
             var cursor = 0;
@@ -67,67 +59,75 @@ public class DevRuntimeSink implements NonStandardSink, Closeable {
                 if (logger.length() <= LOGGER_NAME_FOLDING_THRESHOLD) break;
             }
         }
-        logData.append(" ".repeat(Math.max(34 - logEvent.threadName.length - logger.length(), 1)));
-        logData.append(colorize(logger.toString(), Attribute.BOLD(), getColor(new String(logEvent.logger))));
-        logData.append(colorize(" |", Attribute.BOLD()));
+        log.append(" ".repeat(Math.max(34 - logEvent.threadName.length - logger.length(), 1)))
+                .append(colorize(logger.toString(), Attribute.BOLD(), getColor(new String(logEvent.logger))))
+                .append(colorize(" | ", Attribute.BOLD()));
+
+    }
+
+    @Override
+    public void write(PennaLogEvent logEvent) throws IOException {
+        init();
+        StringBuilder log = new StringBuilder();
+        // Headers
+        emitHeader(log, logEvent);
 
         // Metadata
         if(mdcAdapter.isNotEmpty()) {
-            logData.append(colorize(" mdc{", Attribute.ITALIC()));
+            log.append(colorize("mdc{", Attribute.ITALIC()));
 
             mdcAdapter.forEach((key, value) -> {
-                logData.append(colorize(key, Attribute.BOLD(), getColor(key)));
-                logData.append("=");
-                logData.append(colorize(value, Attribute.BOLD()));
-                logData.append(" ");
+                log.append(colorize(key, Attribute.BOLD(), getColor(key)))
+                        .append('=')
+                        .append(colorize(value, Attribute.BOLD()))
+                        .append(' ');
             });
-            logData.deleteCharAt(logData.length() - 1);
-            logData.append(colorize("}", Attribute.ITALIC()));
+            log.deleteCharAt(log.length() - 1)
+                    .append(colorize("}", Attribute.ITALIC()));
         }
 
-        logData.append(" ");
         if(!logEvent.markers.isEmpty()) {
             logEvent.markers.forEach(key -> {
                 var kvColor = getColor(key.getName());
-                logData.append(colorize("#", Attribute.BOLD(), kvColor));
-                logData.append(colorize(key.getName(), Attribute.BOLD(), kvColor));
-                logData.append(" ");
+                log.append(colorize("#", Attribute.BOLD(), kvColor))
+                        .append(colorize(key.getName(), Attribute.BOLD(), kvColor))
+                        .append(' ');
             });
         }
 
-        logData.append(Formatter.format(logEvent.message, logEvent.arguments));
+        log.append(Formatter.format(logEvent.message, logEvent.arguments));
 
         if(!logEvent.keyValuePairs.isEmpty()) {
-            logData.append(colorize(" kvs{", Attribute.ITALIC()));
+            log.append(colorize(" kvs{", Attribute.ITALIC()));
 
             logEvent.keyValuePairs.forEach((kvp) -> {
-                logData.append(colorize(kvp.key, Attribute.BOLD(), getColor(kvp.key)));
-                logData.append("=");
-                logData.append(colorize(kvp.value.toString(), Attribute.BOLD()));
-                logData.append(" ");
+                log.append(colorize(kvp.key, Attribute.BOLD(), getColor(kvp.key)))
+                        .append('=')
+                        .append(colorize(kvp.value.toString(), Attribute.BOLD()))
+                        .append(' ');
             });
-            logData.deleteCharAt(logData.length() - 1);
-            logData.append(colorize("}", Attribute.ITALIC()));
+            log.deleteCharAt(log.length() - 1)
+                    .append(colorize("}", Attribute.ITALIC()));
         }
 
 
         if (logEvent.throwable != null) {
             var throwable = logEvent.throwable;
-            logData.append("\n");
-            logData.append(colorize(" ❌ ", Attribute.BOLD(), Attribute.BRIGHT_RED_TEXT()));
-            logData.append(colorize(throwable.getClass().getName(), Attribute.YELLOW_TEXT()));
-            logData.append(colorize(": ", Attribute.BOLD(), Attribute.YELLOW_TEXT()));
-            logData.append(colorize(throwable.getMessage(), Attribute.YELLOW_TEXT()));
-            logData.append("\n");
+            log.append('\n')
+                    .append(colorize(" ❌ ", Attribute.BOLD(), Attribute.BRIGHT_RED_TEXT()))
+                    .append(colorize(throwable.getClass().getName(), Attribute.YELLOW_TEXT()))
+                    .append(colorize(": ", Attribute.BOLD(), Attribute.YELLOW_TEXT()))
+                    .append(colorize(throwable.getMessage(), Attribute.YELLOW_TEXT()))
+                    .append('\n');
             for(StackTraceElement ste : throwable.getStackTrace()) {
-                logData.append("\t");
-                logData.append(ste.toString());
-                logData.append("\n");
+                log.append('\t')
+                        .append(ste.toString())
+                        .append('\n');
             }
-            logData.deleteCharAt(logData.length() - 1);
+            log.deleteCharAt(log.length() - 1);
         }
 
-        ps.println(logData);
+        ps.println(log);
         ps.flush();
     }
 

--- a/penna-dev/src/test/java/penna/dev/FormatterTest.java
+++ b/penna-dev/src/test/java/penna/dev/FormatterTest.java
@@ -1,0 +1,50 @@
+package penna.dev;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import penna.dev.Formatter;
+
+class FormatterTest {
+
+    @Test
+    void no_args_means_identity() {
+        Assertions.assertEquals("No args", Formatter.format("No args", new Object[]{}));
+    }
+
+    @Test
+    void can_format_one_arg() {
+        Assertions.assertEquals("one arg", Formatter.format("{} arg", new Object[]{"one"}));
+        Assertions.assertEquals("1 arg", Formatter.format("{} arg", new Object[]{1}));
+        Assertions.assertEquals("1.0 arg", Formatter.format("{} arg", new Object[]{1.0}));
+        Assertions.assertEquals("null arg", Formatter.format("{} arg", new Object[]{null}));
+    }
+
+    @Test
+    void excess_args_dont_break() {
+        Assertions.assertEquals("one arg", Formatter.format("{} arg", new Object[]{"one", "two"}));
+        Assertions.assertEquals("1 arg", Formatter.format("{} arg", new Object[]{1, 2}));
+        Assertions.assertEquals("1.0 arg", Formatter.format("{} arg", new Object[]{1.0, 2.1}));
+        Assertions.assertEquals("null arg", Formatter.format("{} arg", new Object[]{null, null}));
+    }
+
+    @Test
+    void missing_args_dont_break() {
+        Assertions.assertEquals("one arg {}", Formatter.format("{} arg {}", new Object[]{"one"}));
+        Assertions.assertEquals("two args and {}", Formatter.format("{} args {} {}", new Object[]{"two", "and"}));
+    }
+
+
+    @Test
+    void single_escaped_blocks_are_ignored() {
+        Assertions.assertEquals("\\{} arg one", Formatter.format("\\{} arg {}", new Object[]{"one"}));
+        Assertions.assertEquals("\\{} args \\{} two", Formatter.format("\\{} args \\{} {}", new Object[]{"two", "and"}));
+    }
+
+
+    @Test
+    void double_escaped_blocks_are_formatted() {
+        Assertions.assertEquals("\\\\one arg {}", Formatter.format("\\\\{} arg {}", new Object[]{"one"}));
+        Assertions.assertEquals("\\{} args \\\\two and", Formatter.format("\\{} args \\\\{} {}", new Object[]{"two", "and"}));
+    }
+
+}

--- a/penna-yaml-config/build.gradle
+++ b/penna-yaml-config/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.hkupty.penna'
-version '0.7.0-alpha1'
+version '0.7.0-alpha2'
 
 pmd {
     sourceSets = [sourceSets.main]


### PR DESCRIPTION
Some logs seem to pass `null` as argument to format.
This causes NPE in both sinks, so we need to fix ASAP.