### PR TITLE
Version added to MANIFEST.MF

### DIFF
--- a/penna-api/build.gradle
+++ b/penna-api/build.gradle
@@ -45,3 +45,9 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+jar {
+    manifest {
+        attributes('Implementation-Version': project.version)
+    }
+}


### PR DESCRIPTION
I've added the library version to the MANIFEST.MF file so that ```StdoutLogger.class.getPackage().getImplementationVersion();``` can be used in the initialization logging.